### PR TITLE
Fix bug in caravans with comfort precept

### DIFF
--- a/Source/Comfort.cs
+++ b/Source/Comfort.cs
@@ -110,6 +110,9 @@ namespace MorePrecepts
                 ThoughtDef thoughtDef, Precept precept) = ComfortHelper.GetComfort(ingester);
             if(thoughtDef == null)
                 return;
+            // Map is null when on caravan; don't give mood for comfort since the player can't control it
+            if (ingester.Map == null)
+                return;
             Thing thing = __instance;
             // The comfort+ingest code is in Toils_Ingest, but Thing.Ingested is easier to patch.
             // chair


### PR DESCRIPTION
Caravans with the comfort precept will immediately consume all food and gain zero nutrition because this patch has a NullReferenceException on ingester.Map

I haven't tested this (since I don't feel like setting up the build) but I'm fairly sure this is the problem